### PR TITLE
Fix health query typo

### DIFF
--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -2,7 +2,7 @@ import { User } from './models/User';
 
 export const resolvers = {
   Query: {
-    healty: () => 'Graphql server is healthy',
+    healthy: () => 'Graphql server is healthy',
     users: () => User.find()
   },
   Mutation: {

--- a/src/typeDefs.js
+++ b/src/typeDefs.js
@@ -5,7 +5,7 @@ export const typeDefs = gql`
   scalar Long
 
   type Query {
-    healty: String    
+    healthy: String
     users: [User!]!
   }
 


### PR DESCRIPTION
## Summary
- rename `healty` field to `healthy` in schema and resolvers

## Testing
- `npm start` *(fails: MongoDB not running)*

------
https://chatgpt.com/codex/tasks/task_e_68484d3196a8832bb86fdd872e7b7879