### PR TITLE
Update createUser resolver

### DIFF
--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -7,21 +7,20 @@ export const resolvers = {
   },
   Mutation: {
     createUser: async (_, { name, surname, email, birthDate = "", phone = "" }) => {
-      const user = new User({ name, surname, email, birthDate, phone });
-      let foundUser = [];
+      try {
+        const user = new User({ name, surname, email, birthDate, phone });
+        const foundUser = await User.find({ email });
 
-      await User.find((_, item) => {
-        foundUser = item.filter(usr => usr.email === email);
-      });
+        if (foundUser.length === 0) {
+          await user.save();
+        } else {
+          return new Error(`${email} already exist please check your information`);
+        }
 
-      if (foundUser.length === 0) {
-        await user.save();
+        return user;
+      } catch (error) {
+        throw new Error('Failed to create user');
       }
-      else {
-        return new Error(`${email} already exist please check your information`);
-      }
-
-      return user;
     },
     updateUser: async (_, { id }) => {
       console.log(id);


### PR DESCRIPTION
## Summary
- refactor `createUser` resolver to use `await User.find({ email })`
- handle errors using try/catch

## Testing
- `npm install`
- `npm start` *(fails: Error: read EIO)*

------
https://chatgpt.com/codex/tasks/task_e_68484d9a2bd8832b96da026953402f10